### PR TITLE
- removing settings for personal display and resources on target

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -1011,7 +1011,7 @@ Plater.DefaultSpellRangeList = {
 
 	--> return true if the resource bar should shown above the nameplate in the current target nameplate
 	function Plater.IsShowingResourcesOnTarget() --private
-		return GetCVar ("nameplateShowSelf") == CVAR_ENABLED and GetCVar ("nameplateResourceOnTarget") == CVAR_ENABLED
+		return Plater.db.profile.resource_on_target
 	end
 	
 	--> when the player left a zone but is in combat, wait 1 second and trigger the zone changed again
@@ -1132,7 +1132,6 @@ Plater.DefaultSpellRangeList = {
 		
 		--> personal and resources
 		cvarTable ["nameplateShowSelf"] = GetCVar ("nameplateShowSelf")
-		cvarTable ["nameplateResourceOnTarget"] = GetCVar ("nameplateResourceOnTarget")
 		cvarTable ["nameplatePersonalShowAlways"] = GetCVar ("nameplatePersonalShowAlways")
 		cvarTable ["nameplatePersonalShowWithTarget"] = GetCVar ("nameplatePersonalShowWithTarget")
 		cvarTable ["nameplatePersonalShowInCombat"] = GetCVar ("nameplatePersonalShowInCombat")
@@ -3118,7 +3117,7 @@ function Plater.OnInit() --private
 		function Plater.UpdatePersonalBar (self)
 			local showSelf = GetCVarBool ("nameplateShowSelf")
 			if (not showSelf) then
-				if (GetCVarBool ("nameplateResourceOnTarget")) then
+				if Plater.db.profile.resource_on_target then
 					Plater.UpdateResourceFrame()
 				end
 				return
@@ -3210,7 +3209,7 @@ function Plater.OnInit() --private
 			local onCurrentTarget
 			
 			if (not showSelf) then
-				onCurrentTarget = GetCVarBool ("nameplateResourceOnTarget")
+				onCurrentTarget = Plater.db.profile.resource_on_target
 				if (not onCurrentTarget) then
 					return
 				end
@@ -3226,7 +3225,7 @@ function Plater.OnInit() --private
 			resourceFrame:SetAlpha (Plater.db.profile.resources.alpha)
 			
 			--check if resources are placed on the current target
-			onCurrentTarget = GetCVarBool ("nameplateResourceOnTarget")
+			onCurrentTarget = Plater.db.profile.resource_on_target
 			if (onCurrentTarget) then
 				--resource bar are placed on the current target nameplate
 				local targetPlateFrame = C_NamePlate.GetNamePlateForUnit ("target")
@@ -6776,7 +6775,7 @@ end
 	function Plater.ForceChangeBorderColor (self, r, g, b) --private --self = unitFrame
 		--this call is from the retail game, file: blizzard_nameplates.lua
 		if (not self.customBorderColor) then
-			self.healthBar.border:SetVertexColor (r, g, b)
+--			self.healthBar.border:SetVertexColor (r, g, b)
 			self.BorderIsAggroIndicator = true
 		end
 	end
@@ -7886,7 +7885,6 @@ function Plater.SetCVarsOnFirstRun()
 	
 	--disabled:
 		--SetCVar ("nameplateShowSelf", CVAR_DISABLED)
-		--SetCVar ("nameplateResourceOnTarget", CVAR_DISABLED)
 		--SetCVar ("nameplateShowFriends", CVAR_ENABLED)
 	--> location of the personal bar
 	--	SetCVar ("nameplateSelfBottomInset", 20 / 100)

--- a/Plater_DefaultSettings.lua
+++ b/Plater_DefaultSettings.lua
@@ -501,6 +501,8 @@ PLATER_DEFAULT_SETTINGS = {
 		show_health_prediction = false,
 		show_shield_prediction = false,
 		
+		resource_on_target = true,
+		
 		show_interrupt_author = true,
 		
 		--allow scripts to store default values of cvars when they perform automatically changes

--- a/Plater_OptionsPanel.lua
+++ b/Plater_OptionsPanel.lua
@@ -44,7 +44,6 @@ local mainHeightSize = 800
  --cvars
 local CVAR_ENABLED = "1"
 local CVAR_DISABLED = "0"
-local CVAR_RESOURCEONTARGET = "nameplateResourceOnTarget"
 local CVAR_CULLINGDISTANCE = "nameplateMaxDistance"
 local CVAR_AGGROFLASH = "ShowNamePlateLoseAggroFlash"
 local CVAR_MOVEMENT_SPEED = "nameplateMotionSpeed"
@@ -727,7 +726,7 @@ local nameplate_anchor_options = {
 local interface_options = {
 
 		--{type = "label", get = function() return "Interface Options:" end, text_template = DF:GetTemplate ("font", "ORANGE_FONT_TEMPLATE")},
-
+--[[
 		{
 			type = "toggle",
 			get = function() return GetCVar ("nameplateShowSelf") == CVAR_ENABLED end,
@@ -743,21 +742,18 @@ local interface_options = {
 			desc = "Shows a mini health and mana bars under your character." .. CVarDesc,
 			nocombat = true,
 		},
-		{
+--]]
+--[[		{
 			type = "toggle",
-			get = function() return GetCVar (CVAR_RESOURCEONTARGET) == CVAR_ENABLED end,
+			get = function() return Plater.db.profile.resource_on_target end,
 			set = function (self, fixedparam, value) 
-				if (not InCombatLockdown()) then
-					SetCVar (CVAR_RESOURCEONTARGET, math.abs (tonumber (GetCVar (CVAR_RESOURCEONTARGET))-1))
-				else
-					Plater:Msg (L["OPTIONS_ERROR_CVARMODIFY"])
-					self:SetValue (GetCVar (CVAR_RESOURCEONTARGET) == CVAR_ENABLED)
-				end
+				Plater.db.profile.resource_on_target = value
 			end,
 			name = "Show Resources on Target" .. CVarIcon,
-			desc = "Shows your resource such as combo points above your current target.\n\n'Personal Health and Mana Bars' has to be enabled" .. CVarDesc,
+			desc = "Shows your resource such as combo points above your current target.",
 			nocombat = true,
 		},
+--]]
 		{
 			type = "toggle",
 			get = function() return GetCVar (CVAR_SHOWALL) == CVAR_ENABLED end,


### PR DESCRIPTION
Personal nameplate does not exist and resource on target needs some rework, as the implementation does not work for classic.