### PR TITLE
Option for player names

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -6303,7 +6303,7 @@ end
 			--return
 			--needReset = true
 			
-		elseif (plateFrame.IsFriendlyPlayerWithoutHealthBar) then --not critical code
+		elseif (plateFrame.IsFriendlyPlayerWithoutHealthBar) and (not plateFrame.IsFriendlyPlayerWithoutName) then --not critical code
 			--when the option to show only the player name is enabled
 			--special string to show the player name
 			local nameFontString = plateFrame.ActorNameSpecial
@@ -7556,7 +7556,7 @@ end
 		anchor_functions [config.side] (widget, config, attachTo, centered)
 	end
 
-	--check the setting 'only_damaged' and 'only_thename' for player characters. not critical code, can run slow
+	--check the setting 'only_damaged', 'only_thename', and 'hide_thename' for player characters. not critical code, can run slow
 	function Plater.ParseHealthSettingForPlayer (plateFrame) --private
 		plateFrame.IsFriendlyPlayerWithoutHealthBar = false
 
@@ -7577,6 +7577,13 @@ end
 			
 		else
 			Plater.ShowHealthBar (plateFrame.unitFrame)
+		end
+		if (DB_PLATE_CONFIG [ACTORTYPE_FRIENDLY_PLAYER].hide_thename) then
+			Plater.HideName (plateFrame.unitFrame)
+			plateFrame.IsFriendlyPlayerWithoutName = true
+		else
+			Plater.ShowName (plateFrame.unitFrame)
+			plateFrame.IsFriendlyPlayerWithoutName = false
 		end
 	end
 
@@ -9321,6 +9328,15 @@ end
 		elseif (showNameNpc) then
 			Plater.UpdatePlateText (unitFrame.PlateFrame, DB_PLATE_CONFIG [ACTORTYPE_ENEMY_NPC], true)
 		end
+	end
+	
+	--hide the name
+	function Plater.HideName (unitFrame)
+		unitFrame.unitName:Hide()
+	end
+	--show the name
+	function Plater.ShowName (unitFrame)
+		unitFrame.unitName:Show()
 	end
 	
 	--forces a range check regardless of the user options and only changes the member_range flag, no alpha changes

--- a/Plater.lua
+++ b/Plater.lua
@@ -6763,6 +6763,14 @@ end
 				Plater.AddGuildNameToPlayerName (plateFrame)
 			end
 		end
+		
+		-- Check if we should hide player name or not
+		if (plateFrame.PlateConfig.hide_thename) then
+			Plater.HideName (plateFrame.unitFrame)
+		else
+			Plater.ShowName (plateFrame.unitFrame)
+		end
+
 	end
 
 	function Plater.UpdateUnitNameTextSize (plateFrame, nameString)
@@ -7556,7 +7564,7 @@ end
 		anchor_functions [config.side] (widget, config, attachTo, centered)
 	end
 
-	--check the setting 'only_damaged', 'only_thename', and 'hide_thename' for player characters. not critical code, can run slow
+	--check the setting 'only_damaged' and 'only_thename' for player characters. not critical code, can run slow
 	function Plater.ParseHealthSettingForPlayer (plateFrame) --private
 		plateFrame.IsFriendlyPlayerWithoutHealthBar = false
 
@@ -7578,6 +7586,7 @@ end
 		else
 			Plater.ShowHealthBar (plateFrame.unitFrame)
 		end
+		-- Check if we should hide friendly player names
 		if (DB_PLATE_CONFIG [ACTORTYPE_FRIENDLY_PLAYER].hide_thename) then
 			Plater.HideName (plateFrame.unitFrame)
 			plateFrame.IsFriendlyPlayerWithoutName = true

--- a/Plater_DefaultSettings.lua
+++ b/Plater_DefaultSettings.lua
@@ -93,6 +93,7 @@ PLATER_DEFAULT_SETTINGS = {
 				enabled = true,
 				only_damaged = true,
 				only_thename = false,
+				hide_thename = false,
 				click_through = true,
 				show_guild_name = false,
 				

--- a/Plater_DefaultSettings.lua
+++ b/Plater_DefaultSettings.lua
@@ -166,6 +166,7 @@ PLATER_DEFAULT_SETTINGS = {
 			enemyplayer = {
 				enabled = true,
 				show_guild_name = false,
+				hide_thename = false,
 				
 				use_playerclass_color = true,
 				fixed_class_color = {1, .4, .1},

--- a/Plater_OptionsPanel.lua
+++ b/Plater_OptionsPanel.lua
@@ -6974,8 +6974,18 @@ local relevance_options = {
 				Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].only_thename = value
 				Plater.UpdateAllPlates()
 			end,
-			name = "Only Show Player Name",
-			desc = "Hide the health bar, only show the character name.\n\n|cFFFFFF00Important|r: If 'Only Damaged Players' is selected and the player is damaged, this setting will be overwritten and the health bar will be shown.",
+			name = "Hide Player Health Bar",
+			desc = "Hide the health bar.\n\n|cFFFFFF00Important|r: If 'Only Damaged Players' is selected and the player is damaged, this setting will be overwritten and the health bar will be shown.",
+		},
+		{
+			type = "toggle",
+			get = function() return Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].hide_thename end,
+			set = function (self, fixedparam, value) 
+				Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].hide_thename = value
+				Plater.UpdateAllPlates()
+			end,
+			name = "Hide Player Name",
+			desc = "Hide friendly player names. \n\n|cFFFFFF00Important|r: Guild name is attached to the name, so if this is checked the below setting will be overwritten.",
 		},
 		{
 			type = "toggle",

--- a/Plater_OptionsPanel.lua
+++ b/Plater_OptionsPanel.lua
@@ -6985,7 +6985,7 @@ local relevance_options = {
 				Plater.UpdateAllPlates()
 			end,
 			name = "Hide Player Name",
-			desc = "Hide friendly player names. \n\n|cFFFFFF00Important|r: Guild name is attached to the name, so if this is checked the below setting will be overwritten.",
+			desc = "Hide friendly players' names. \n\n|cFFFFFF00Important|r: Guild name is attached to the name, so if this is checked the below setting will be overwritten.",
 		},
 		{
 			type = "toggle",
@@ -6995,7 +6995,7 @@ local relevance_options = {
 				Plater.UpdateAllPlates (true)
 			end,
 			name = "Show Guild Name",
-			desc = "Show Guild Name",
+			desc = "Show friendly players' guild name \n\n|cFFFFFF00Important|r: Guild name is attached to the name, so if hide player name is checked this will be overwritten.",
 		},
 		{
 			type = "toggle",
@@ -7915,13 +7915,23 @@ local relevance_options = {
 		},
 		{
 			type = "toggle",
+			get = function() return Plater.db.profile.plate_config.enemyplayer.hide_thename end,
+			set = function (self, fixedparam, value) 
+				Plater.db.profile.plate_config.enemyplayer.hide_thename = value
+				Plater.UpdateAllPlates (true)
+			end,
+			name = "Hide Player Name",
+			desc = "Hide enemy players' names. \n\n|cFFFFFF00Important|r: Guild name is attached to the name, so if this is checked the below setting will be overwritten.",
+		},
+		{
+			type = "toggle",
 			get = function() return Plater.db.profile.plate_config.enemyplayer.show_guild_name end,
 			set = function (self, fixedparam, value) 
 				Plater.db.profile.plate_config.enemyplayer.show_guild_name = value
 				Plater.UpdateAllPlates (true)
 			end,
 			name = "Show Guild Name",
-			desc = "Show Guild Name",
+			desc = "Show enemy players' guild name \n\n|cFFFFFF00Important|r: Guild name is attached to the name, so if hide player name is checked this will be overwritten.",
 		},
 		
 		{type = "blank"},


### PR DESCRIPTION
This adds an option for and functionality to remove both friendly and enemy player names. I wanted this functionality for myself in BGs, where I especially don't care for friendly names, just health bar by class color. 

Besides adding a new option `hide_thename` (tried to follow your naming conventions, I renamed 'Only Show Player Name' to 'Hide Player Health Bar' to try to more accurately describe it's function. Hiding the player name will also hide the guild name, I added an 'important' message to both tooltips.